### PR TITLE
Prefill submission details with markdown template

### DIFF
--- a/apps/judge/src/app/(participant)/[hackathonId]/submission/form.tsx
+++ b/apps/judge/src/app/(participant)/[hackathonId]/submission/form.tsx
@@ -57,6 +57,34 @@ const ERROR_STEP_MAP: Record<string, number> = {
   otherLinks: 4,
 };
 
+const DEFAULT_DESCRIPTION_TEMPLATE = `## Inspiration
+
+What inspired you to build this project?
+
+## What It Does
+
+Describe the main features and how someone would use it.
+
+## How We Built It
+
+Share the tools, APIs, frameworks, and design decisions behind your project.
+
+## Challenges We Ran Into
+
+What was difficult, surprising, or especially interesting to solve?
+
+## Accomplishments That We Are Proud Of
+
+What are you most excited about?
+
+## What We Learned
+
+What did your team learn while building this?
+
+## What Is Next
+
+Where would you take this project after the hackathon?`;
+
 interface SubmissionFormProps {
   hackathonId: string;
   initialData: InitialData;
@@ -121,7 +149,7 @@ export function SubmissionForm({
     defaultValues: {
       title: initialData?.title ?? "",
       tagline: initialData?.tagline ?? "",
-      description: initialData?.description ?? "",
+      description: initialData?.description ?? DEFAULT_DESCRIPTION_TEMPLATE,
       videoUrl: initialData?.videoUrl ?? "",
       images: initialData?.images ?? [],
       githubUrl: initialData?.githubUrl ?? "",


### PR DESCRIPTION
## Summary
- Prefill new submission descriptions with a Devpost-style Markdown outline.
- Keep existing drafts and submitted projects using their saved description content.

## Test plan
- pnpm --filter judge lint
- pnpm --filter judge exec tsc --noEmit (fails on pre-existing stale .next generated type imports)